### PR TITLE
Add Assigned*Attribute to all existing attribute types

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime
 from typing import cast
 
 import graphene
@@ -680,19 +681,14 @@ class SelectedAttribute(graphene.Interface):
         if instance.attribute.node.input_type == AttributeInputType.REFERENCE:
             entity_type = cast(str, instance.attribute.node.entity_type)
             return ASSIGNED_MULTI_REFERENCE_MAP.get(entity_type)
-        attr_type = ASSIGNED_ATTRIBUTE_MAP.get(
-            instance.attribute.node.input_type,
-        )
-        if not attr_type:
-            # It is only a temporary until introducing the rest of the types.
-            return AssignedNumericAttribute
+        attr_type = ASSIGNED_ATTRIBUTE_MAP[instance.attribute.node.input_type]
         return attr_type
 
 
 class AssignedNumericAttribute(BaseObjectType):
     value = graphene.Float(
         required=False,
-        description="Numeric value of an attribute.",
+        description="The assigned numeric value.",
     )
 
     class Meta:
@@ -711,7 +707,7 @@ class AssignedNumericAttribute(BaseObjectType):
 class AssignedTextAttribute(BaseObjectType):
     value = graphene.Field(
         JSON,
-        description="Rich text content.",
+        description="The assigned rich text content.",
         required=False,
     )
 
@@ -721,7 +717,7 @@ class AssignedTextAttribute(BaseObjectType):
             LanguageCodeEnum,
             required=True,
         ),
-        description="Translation of the rich text content.",
+        description="Translation of the rich text content in the specified language.",
         required=False,
     )
 
@@ -759,7 +755,7 @@ class AssignedTextAttribute(BaseObjectType):
 
 class AssignedPlainTextAttribute(BaseObjectType):
     value = graphene.String(
-        description="Plain text content.",
+        description="The assigned plain text content.",
         required=False,
     )
 
@@ -769,7 +765,7 @@ class AssignedPlainTextAttribute(BaseObjectType):
             LanguageCodeEnum,
             required=True,
         ),
-        description="Translation of the plain text content.",
+        description="Translation of the plain text content in the specified language.",
         required=False,
     )
 
@@ -806,9 +802,7 @@ class AssignedPlainTextAttribute(BaseObjectType):
 
 
 class AssignedFileAttribute(BaseObjectType):
-    value = graphene.Field(
-        File, description=AttributeValueDescriptions.FILE, required=False
-    )
+    value = graphene.Field(File, description="The assigned file.", required=False)
 
     class Meta:
         interfaces = [SelectedAttribute]
@@ -825,7 +819,7 @@ class AssignedFileAttribute(BaseObjectType):
 class AssignedSinglePageReferenceAttribute(BaseObjectType):
     value = graphene.Field(
         "saleor.graphql.page.types.Page",
-        description="Referenced page.",
+        description="The assigned page reference.",
         required=False,
     )
 
@@ -853,7 +847,7 @@ class AssignedSinglePageReferenceAttribute(BaseObjectType):
 class AssignedSingleProductReferenceAttribute(BaseObjectType):
     value = graphene.Field(
         "saleor.graphql.product.types.Product",
-        description="Referenced product.",
+        description="The assigned product reference.",
         required=False,
     )
 
@@ -883,7 +877,7 @@ class AssignedSingleProductReferenceAttribute(BaseObjectType):
 class AssignedSingleProductVariantReferenceAttribute(BaseObjectType):
     value = graphene.Field(
         "saleor.graphql.product.types.ProductVariant",
-        description="Referenced product variant.",
+        description="The assigned product variant reference.",
         required=False,
     )
 
@@ -917,7 +911,7 @@ class AssignedSingleProductVariantReferenceAttribute(BaseObjectType):
 class AssignedSingleCategoryReferenceAttribute(BaseObjectType):
     value = graphene.Field(
         "saleor.graphql.product.types.Category",
-        description="Referenced category.",
+        description="The assigned category reference.",
         required=False,
     )
 
@@ -938,7 +932,7 @@ class AssignedSingleCategoryReferenceAttribute(BaseObjectType):
 class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
     value = graphene.Field(
         "saleor.graphql.product.types.Collection",
-        description="Referenced collection.",
+        description="The assigned collection reference.",
         required=False,
     )
 
@@ -970,7 +964,7 @@ class AssignedSingleCollectionReferenceAttribute(BaseObjectType):
 class AssignedMultiPageReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.page.types.Page",
-        description="List of referenced pages.",
+        description="List of assigned page references.",
         required=True,
     )
 
@@ -1007,7 +1001,7 @@ class AssignedMultiPageReferenceAttribute(BaseObjectType):
 class AssignedMultiProductReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.Product",
-        description="List of referenced products.",
+        description="List of assigned product references.",
         required=True,
     )
 
@@ -1045,7 +1039,7 @@ class AssignedMultiProductReferenceAttribute(BaseObjectType):
 class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.ProductVariant",
-        description="List of referenced product variants.",
+        description="List of assigned product variant references.",
         required=True,
     )
 
@@ -1085,7 +1079,7 @@ class AssignedMultiProductVariantReferenceAttribute(BaseObjectType):
 class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.Category",
-        description="List of referenced categories.",
+        description="List of assigned category references.",
         required=True,
     )
 
@@ -1109,7 +1103,7 @@ class AssignedMultiCategoryReferenceAttribute(BaseObjectType):
 class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
     value = NonNullList(
         "saleor.graphql.product.types.Collection",
-        description="List of referenced collections.",
+        description="List of assigned collection references.",
         required=True,
     )
 
@@ -1144,6 +1138,181 @@ class AssignedMultiCollectionReferenceAttribute(BaseObjectType):
         )
 
 
+class AssignedChoiceAttributeValue(BaseObjectType):
+    name = graphene.String(description=AttributeValueDescriptions.NAME)
+    slug = graphene.String(description=AttributeValueDescriptions.SLUG)
+    translation = graphene.String(
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            required=True,
+        ),
+        description="Translation of the name.",
+        required=False,
+    )
+
+    class Meta:
+        description = (
+            "Represents a single choice value of the attribute." + ADDED_IN_322
+        )
+
+    @staticmethod
+    def resolve_translation(
+        root: AttributeValue, info: ResolveInfo, *, language_code
+    ) -> Promise[str | None] | None:
+        return (
+            AttributeValueTranslationByIdAndLanguageCodeLoader(info.context)
+            .load((root.id, language_code))
+            .then(lambda translation: translation.name if translation else None)
+        )
+
+
+class AssignedSingleChoiceAttribute(BaseObjectType):
+    value = graphene.Field(
+        AssignedChoiceAttributeValue,
+        required=False,
+        description="The assigned choice value.",
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents a single choice attribute." + ADDED_IN_322
+
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> models.AttributeValue | None:
+        if not root.values:
+            return None
+        attr_value = root.values[0].node
+        return attr_value
+
+
+class AssignedMultiChoiceAttribute(BaseObjectType):
+    value = NonNullList(
+        AssignedChoiceAttributeValue,
+        required=True,
+        description="List of assigned choice values.",
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents a multi choice attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, info: ResolveInfo
+    ) -> list[models.AttributeValue]:
+        return [value.node for value in root.values]
+
+
+class AssignedSwatchAttributeValue(BaseObjectType):
+    name = graphene.String(
+        description="Name of the selected swatch value. ",
+        required=False,
+    )
+    slug = graphene.String(
+        description="Slug of the selected swatch value.",
+        required=False,
+    )
+    hex_color = graphene.String(
+        required=False,
+        description="Hex color code.",
+    )
+    file = graphene.Field(
+        File, description="File associated with the attribute.", required=False
+    )
+
+    @staticmethod
+    def resolve_hex_color(
+        root: models.AttributeValue, _info: ResolveInfo
+    ) -> str | None:
+        return root.value
+
+    @staticmethod
+    def resolve_file(root: models.AttributeValue, _info: ResolveInfo) -> File | None:
+        if not root.file_url:
+            return None
+        return File(url=root.file_url, content_type=root.content_type)
+
+
+class AssignedSwatchAttribute(BaseObjectType):
+    value = graphene.Field(
+        AssignedSwatchAttributeValue,
+        required=False,
+        description="The assigned swatch value.",
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents a swatch attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, _info: ResolveInfo
+    ) -> models.AttributeValue | None:
+        if not root.values:
+            return None
+        attr_value = root.values[0].node
+        return attr_value
+
+
+class AssignedBooleanAttribute(BaseObjectType):
+    value = graphene.Boolean(
+        description="The assigned boolean value.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents a boolean attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(root: SelectedAttributeData, _info: ResolveInfo) -> bool | None:
+        if not root.values:
+            return None
+        attr_value = root.values[0].node
+        return attr_value.boolean
+
+
+class AssignedDateAttribute(BaseObjectType):
+    value = graphene.Field(
+        Date,
+        description="The assigned date value.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents a date attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(root: SelectedAttributeData, _info: ResolveInfo) -> date | None:
+        if not root.values:
+            return None
+        attr_value = root.values[0].node
+        return attr_value.date_time.date() if attr_value.date_time else None
+
+
+class AssignedDateTimeAttribute(BaseObjectType):
+    value = graphene.Field(
+        DateTime,
+        description="The assigned date time value.",
+        required=False,
+    )
+
+    class Meta:
+        interfaces = [SelectedAttribute]
+        description = "Represents a date time attribute." + ADDED_IN_322
+
+    @staticmethod
+    def resolve_value(
+        root: SelectedAttributeData, _info: ResolveInfo
+    ) -> datetime | None:
+        if not root.values:
+            return None
+        attr_value = root.values[0].node
+        return attr_value.date_time
+
+
 ASSIGNED_SINGLE_REFERENCE_MAP = {
     AttributeEntityType.PAGE: AssignedSinglePageReferenceAttribute,
     AttributeEntityType.PRODUCT: AssignedSingleProductReferenceAttribute,
@@ -1163,6 +1332,12 @@ ASSIGNED_ATTRIBUTE_MAP = {
     AttributeInputType.RICH_TEXT: AssignedTextAttribute,
     AttributeInputType.PLAIN_TEXT: AssignedPlainTextAttribute,
     AttributeInputType.FILE: AssignedFileAttribute,
+    AttributeInputType.DROPDOWN: AssignedSingleChoiceAttribute,
+    AttributeInputType.MULTISELECT: AssignedMultiChoiceAttribute,
+    AttributeInputType.SWATCH: AssignedSwatchAttribute,
+    AttributeInputType.BOOLEAN: AssignedBooleanAttribute,
+    AttributeInputType.DATE: AssignedDateAttribute,
+    AttributeInputType.DATE_TIME: AssignedDateTimeAttribute,
 }
 ASSIGNED_ATTRIBUTE_TYPES = (
     list(ASSIGNED_ATTRIBUTE_MAP.values())

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -33,12 +33,6 @@ PAGE_QUERY = """
                     id
                     slug
                 }
-                ... on AssignedNumericAttribute {
-                    attribute {
-                        id
-                    }
-                    value
-                }
             }
         }
     }
@@ -92,7 +86,6 @@ def test_query_published_page(user_api_client, page):
             {
                 "attribute": {"id": attr_id, "slug": attr.slug},
                 "values": values,
-                "value": None,
             }
         )
 

--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -250,115 +250,151 @@ def test_query_pages_with_sort(
 
 
 PAGES_QUERY = """
-    query {
-        pages(first: 10) {
-            edges {
-                node {
-                    id
-                    title
-                    slug
-                    pageType {
-                        id
-                    }
-                    content
-                    contentJson
-                    attributes {
-                        attribute {
-                            slug
-                        }
-                        values {
-                            id
-                            slug
-                        }
-                        ... on AssignedNumericAttribute {
-                            attribute {
-                                id
-                            }
-                            value
-                        }
-                        ...on AssignedTextAttribute{
-                            text:value
-                            text_translation: translation(languageCode:FR)
-                        }
-                        ...on AssignedPlainTextAttribute{
-                            plain_text: value
-                            plain_translation: translation(languageCode:FR)
-                        }
-                        ...on AssignedFileAttribute{
-                            file: value {
-                                contentType
-                            }
-                        }
-                        ...on AssignedSinglePageReferenceAttribute{
-                            page_ref: value{
-                                __typename
-                                slug
-                            }
-                        }
-                        ...on AssignedSingleProductReferenceAttribute{
-                            product_ref: value{
-                                __typename
-                                slug
-                            }
-                        }
-                        ...on AssignedSingleProductVariantReferenceAttribute{
-                            variant_ref: value{
-                                __typename
-                                sku
-                            }
-                        }
-                        ...on AssignedSingleCategoryReferenceAttribute{
-                            category_ref: value{
-                                __typename
-                                slug
-                            }
-                        }
-                        ...on AssignedSingleCollectionReferenceAttribute{
-                            collection_ref: value{
-                                __typename
-                                slug
-                            }
-                        }
-                        ...on AssignedMultiPageReferenceAttribute{
-                            __typename
-                            pages: value{
-                                __typename
-                                slug
-                            }
-                        }
-                        ...on AssignedMultiProductReferenceAttribute{
-                            __typename
-                            producs: value{
-                                __typename
-                                slug
-                            }
-                        }
-                        ...on AssignedMultiProductVariantReferenceAttribute{
-                            __typename
-                            variants: value{
-                                __typename
-                                sku
-                            }
-                        }
-                        ...on AssignedMultiCategoryReferenceAttribute{
-                            __typename
-                            categories: value{
-                                __typename
-                                slug
-                            }
-                        }
-                        ...on AssignedMultiCollectionReferenceAttribute{
-                            __typename
-                            collections: value{
-                                __typename
-                                slug
-                            }
-                        }
-                    }
-                }
-            }
+{
+  pages(first: 10) {
+    edges {
+      node {
+        id
+        title
+        slug
+        pageType {
+          id
         }
+        content
+        contentJson
+        attributes {
+          attribute {
+            slug
+          }
+          values {
+            id
+            slug
+          }
+          ... on AssignedNumericAttribute {
+            attribute {
+              id
+            }
+            value
+          }
+          ... on AssignedTextAttribute {
+            text: value
+            text_translation: translation(languageCode: FR)
+          }
+          ... on AssignedPlainTextAttribute {
+            plain_text: value
+            plain_translation: translation(languageCode: FR)
+          }
+          ... on AssignedFileAttribute {
+            file: value {
+              contentType
+            }
+          }
+          ... on AssignedSinglePageReferenceAttribute {
+            page_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleProductReferenceAttribute {
+            product_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleProductVariantReferenceAttribute {
+            variant_ref: value {
+              __typename
+              sku
+            }
+          }
+          ... on AssignedSingleCategoryReferenceAttribute {
+            category_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleCollectionReferenceAttribute {
+            collection_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiPageReferenceAttribute {
+            __typename
+            pages: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiProductReferenceAttribute {
+            __typename
+            producs: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiProductVariantReferenceAttribute {
+            __typename
+            variants: value {
+              __typename
+              sku
+            }
+          }
+          ... on AssignedMultiCategoryReferenceAttribute {
+            __typename
+            categories: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiCollectionReferenceAttribute {
+            __typename
+            collections: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleChoiceAttribute {
+            __typename
+            choice: value {
+              name
+              slug
+              translation(languageCode: FR)
+            }
+          }
+          ... on AssignedMultiChoiceAttribute {
+            __typename
+            choices: value {
+              name
+              slug
+              translation(languageCode: FR)
+            }
+          }
+          ... on AssignedSwatchAttribute {
+            swatch: value {
+              name
+              slug
+              hexColor
+              file {
+                url
+                contentType
+              }
+            }
+          }
+          ... on AssignedBooleanAttribute {
+            bool: value
+          }
+          ... on AssignedDateAttribute {
+            date: value
+          }
+          ... on AssignedDateTimeAttribute {
+            datetime: value
+          }
+        }
+      }
     }
+  }
+}
 """
 
 

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -25,202 +25,274 @@ from ...tests.utils import get_graphql_content
 from ..enums import ProductAttributeType
 
 QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
-    query ($channel: String){
-      products(first: 1, channel: $channel) {
-        edges {
-          node {
-            attributes {
+query ($channel: String) {
+  products(first: 1, channel: $channel) {
+    edges {
+      node {
+        attributes {
+          attribute {
+            slug
+            type
+          }
+          values {
+            slug
+          }
+          ... on AssignedNumericAttribute {
+            attribute {
+              id
+            }
+            value
+          }
+          ... on AssignedTextAttribute {
+            text: value
+            text_translation: translation(languageCode: FR)
+          }
+          ... on AssignedPlainTextAttribute {
+            plain_text: value
+            plain_translation: translation(languageCode: FR)
+          }
+          ... on AssignedFileAttribute {
+            file: value {
+              contentType
+            }
+          }
+          ... on AssignedSinglePageReferenceAttribute {
+            page_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleProductReferenceAttribute {
+            product_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleProductVariantReferenceAttribute {
+            variant_ref: value {
+              __typename
+              sku
+            }
+          }
+          ... on AssignedSingleCategoryReferenceAttribute {
+            category_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleCollectionReferenceAttribute {
+            collection_ref: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiPageReferenceAttribute {
+            __typename
+            pages: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiProductReferenceAttribute {
+            __typename
+            producs: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiProductVariantReferenceAttribute {
+            __typename
+            variants: value {
+              __typename
+              sku
+            }
+          }
+          ... on AssignedMultiCategoryReferenceAttribute {
+            __typename
+            categories: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedMultiCollectionReferenceAttribute {
+            __typename
+            collections: value {
+              __typename
+              slug
+            }
+          }
+          ... on AssignedSingleChoiceAttribute {
+            __typename
+            choice: value {
+              name
+              slug
+              translation(languageCode: FR)
+            }
+          }
+          ... on AssignedMultiChoiceAttribute {
+            __typename
+            multi: value {
+              name
+              slug
+              translation(languageCode: FR)
+            }
+          }
+          ... on AssignedSwatchAttribute {
+            swatch: value {
+              name
+              slug
+              hexColor
+              file {
+                url
+                contentType
+              }
+            }
+          }
+          ... on AssignedBooleanAttribute {
+            bool: value
+          }
+          ... on AssignedDateAttribute {
+            date: value
+          }
+          ... on AssignedDateTimeAttribute {
+            datetime: value
+          }
+        }
+        variants {
+          attributes {
+            attribute {
+              slug
+              type
+            }
+            values {
+              slug
+            }
+            ... on AssignedNumericAttribute {
               attribute {
+                id
+              }
+              value
+            }
+            ... on AssignedTextAttribute {
+              text: value
+              text_translation: translation(languageCode: FR)
+            }
+            ... on AssignedPlainTextAttribute {
+              plain_text: value
+              plain_translation: translation(languageCode: FR)
+            }
+            ... on AssignedFileAttribute {
+              file: value {
+                contentType
+              }
+            }
+            ... on AssignedSinglePageReferenceAttribute {
+              page_ref: value {
+                __typename
                 slug
-                type
               }
-              values {
+            }
+            ... on AssignedSingleProductReferenceAttribute {
+              product_ref: value {
+                __typename
                 slug
               }
-              ... on AssignedNumericAttribute {
-                attribute {
-                    id
-                }
-                value
+            }
+            ... on AssignedSingleProductVariantReferenceAttribute {
+              variant_ref: value {
+                __typename
+                sku
               }
-              ...on AssignedTextAttribute{
-                text: value
-                text_translation: translation(languageCode:FR)
+            }
+            ... on AssignedSingleCategoryReferenceAttribute {
+              category_ref: value {
+                __typename
+                slug
               }
-              ...on AssignedPlainTextAttribute{
-                plain_text: value
-                plain_translation: translation(languageCode:FR)
+            }
+            ... on AssignedSingleCollectionReferenceAttribute {
+              collection_ref: value {
+                __typename
+                slug
               }
-              ...on AssignedFileAttribute{
-                file: value {
+            }
+            ... on AssignedMultiPageReferenceAttribute {
+              __typename
+              pages: value {
+                __typename
+                slug
+              }
+            }
+            ... on AssignedMultiProductReferenceAttribute {
+              __typename
+              producs: value {
+                __typename
+                slug
+              }
+            }
+            ... on AssignedMultiProductVariantReferenceAttribute {
+              __typename
+              variants: value {
+                __typename
+                sku
+              }
+            }
+            ... on AssignedMultiCategoryReferenceAttribute {
+              __typename
+              categories: value {
+                __typename
+                slug
+              }
+            }
+            ... on AssignedMultiCollectionReferenceAttribute {
+              __typename
+              collections: value {
+                __typename
+                slug
+              }
+            }
+            ... on AssignedSingleChoiceAttribute {
+              __typename
+              choice: value {
+                name
+                slug
+                translation(languageCode: FR)
+              }
+            }
+            ... on AssignedMultiChoiceAttribute {
+              __typename
+              multi: value {
+                name
+                slug
+                translation(languageCode: FR)
+              }
+            }
+            ... on AssignedSwatchAttribute {
+              swatch: value {
+                name
+                slug
+                hexColor
+                file {
+                  url
                   contentType
                 }
               }
-              ...on AssignedSinglePageReferenceAttribute{
-                page_ref: value{
-                  __typename
-                  slug
-                }
-              }
-              ...on AssignedSingleProductReferenceAttribute{
-                product_ref: value{
-                __typename
-                slug
-                }
-              }
-              ...on AssignedSingleProductVariantReferenceAttribute{
-                variant_ref: value{
-                  __typename
-                  sku
-                }
-              }
-              ...on AssignedSingleCategoryReferenceAttribute{
-                category_ref: value{
-                  __typename
-                  slug
-                }
-              }
-              ...on AssignedSingleCollectionReferenceAttribute{
-                collection_ref: value{
-                  __typename
-                  slug
-                }
-              }
-              ...on AssignedMultiPageReferenceAttribute{
-                __typename
-                pages: value{
-                  __typename
-                  slug
-                }
-              }
-              ...on AssignedMultiProductReferenceAttribute{
-                __typename
-                producs: value{
-                  __typename
-                  slug
-                }
-              }
-              ...on AssignedMultiProductVariantReferenceAttribute{
-                __typename
-                variants: value{
-                  __typename
-                  sku
-                }
-              }
-              ...on AssignedMultiCategoryReferenceAttribute{
-                __typename
-                categories: value{
-                  __typename
-                  slug
-                }
-              }
-              ...on AssignedMultiCollectionReferenceAttribute{
-                __typename
-                collections: value{
-                  __typename
-                  slug
-                }
-              }
             }
-            variants {
-              attributes {
-                attribute {
-                  slug
-                  type
-                }
-                values {
-                  slug
-                }
-                ... on AssignedNumericAttribute {
-                  attribute {
-                    id
-                  }
-                  value
-                }
-                ...on AssignedTextAttribute{
-                  text: value
-                  text_translation: translation(languageCode:FR)
-                }
-                ...on AssignedPlainTextAttribute{
-                  plain_text: value
-                  plain_translation: translation(languageCode:FR)
-                }
-                ...on AssignedFileAttribute{
-                  file: value {
-                    contentType
-                  }
-                }
-                ...on AssignedSinglePageReferenceAttribute{
-                  page_ref: value{
-                    __typename
-                    slug
-                  }
-                }
-                ...on AssignedSingleProductReferenceAttribute{
-                  product_ref: value{
-                  __typename
-                  slug
-                  }
-                }
-                ...on AssignedSingleProductVariantReferenceAttribute{
-                  variant_ref: value{
-                    __typename
-                    sku
-                  }
-                }
-                ...on AssignedSingleCategoryReferenceAttribute{
-                  category_ref: value{
-                    __typename
-                    slug
-                  }
-                }
-                ...on AssignedSingleCollectionReferenceAttribute{
-                  collection_ref: value{
-                    __typename
-                    slug
-                  }
-                }
-                ...on AssignedMultiPageReferenceAttribute{
-                  __typename
-                  pages: value{
-                    __typename
-                    slug
-                  }
-                }
-                ...on AssignedMultiProductReferenceAttribute{
-                  __typename
-                  producs: value{
-                    __typename
-                    slug
-                  }
-                }
-                ...on AssignedMultiProductVariantReferenceAttribute{
-                  __typename
-                  variants: value{
-                    __typename
-                    sku
-                  }
-                }
-                ...on AssignedMultiCategoryReferenceAttribute{
-                  __typename
-                  categories: value{
-                    __typename
-                    slug
-                  }
-                }
-                ...on AssignedMultiCollectionReferenceAttribute{
-                  __typename
-                  collections: value{
-                    __typename
-                    slug
-                  }
-                }
-              }
+            ... on AssignedBooleanAttribute {
+              bool: value
+            }
+            ... on AssignedDateAttribute {
+              date: value
+            }
+            ... on AssignedDateTimeAttribute {
+              datetime: value
             }
           }
         }
       }
     }
+  }
+}
 """
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -34479,7 +34479,7 @@ type AssignedNumericAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Numeric value of an attribute."""
+  """The assigned numeric value."""
   value: Float
 }
 
@@ -34495,10 +34495,10 @@ type AssignedTextAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Rich text content."""
+  """The assigned rich text content."""
   value: JSON
 
-  """Translation of the rich text content."""
+  """Translation of the rich text content in the specified language."""
   translation(languageCode: LanguageCodeEnum!): JSON
 }
 
@@ -34514,10 +34514,10 @@ type AssignedPlainTextAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Plain text content."""
+  """The assigned plain text content."""
   value: String
 
-  """Translation of the plain text content."""
+  """Translation of the plain text content in the specified language."""
   translation(languageCode: LanguageCodeEnum!): String
 }
 
@@ -34533,8 +34533,134 @@ type AssignedFileAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Represents file URL and content type (if attribute value is a file)."""
+  """The assigned file."""
   value: File
+}
+
+"""
+Represents a single choice attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedSingleChoiceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """The assigned choice value."""
+  value: AssignedChoiceAttributeValue
+}
+
+"""
+Represents a single choice value of the attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedChoiceAttributeValue {
+  """Name of a value displayed in the interface."""
+  name: String
+
+  """Internal representation of a value (unique per attribute)."""
+  slug: String
+
+  """Translation of the name."""
+  translation(languageCode: LanguageCodeEnum!): String
+}
+
+"""
+Represents a multi choice attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedMultiChoiceAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """List of assigned choice values."""
+  value: [AssignedChoiceAttributeValue!]!
+}
+
+"""
+Represents a swatch attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedSwatchAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """The assigned swatch value."""
+  value: AssignedSwatchAttributeValue
+}
+
+type AssignedSwatchAttributeValue {
+  """Name of the selected swatch value."""
+  name: String
+
+  """Slug of the selected swatch value."""
+  slug: String
+
+  """Hex color code."""
+  hexColor: String
+
+  """File associated with the attribute."""
+  file: File
+}
+
+"""
+Represents a boolean attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedBooleanAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """The assigned boolean value."""
+  value: Boolean
+}
+
+"""
+Represents a date attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedDateAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """The assigned date value."""
+  value: Date
+}
+
+"""
+Represents a date time attribute.
+
+Added in Saleor 3.22.
+"""
+type AssignedDateTimeAttribute implements SelectedAttribute {
+  """Name of an attribute displayed in the interface."""
+  attribute: Attribute!
+
+  """Values of an attribute."""
+  values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
+
+  """The assigned date time value."""
+  value: DateTime
 }
 
 """
@@ -34549,7 +34675,7 @@ type AssignedSinglePageReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Referenced page."""
+  """The assigned page reference."""
   value: Page
 }
 
@@ -34565,7 +34691,7 @@ type AssignedSingleProductReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Referenced product."""
+  """The assigned product reference."""
   value: Product
 }
 
@@ -34581,7 +34707,7 @@ type AssignedSingleProductVariantReferenceAttribute implements SelectedAttribute
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Referenced product variant."""
+  """The assigned product variant reference."""
   value: ProductVariant
 }
 
@@ -34597,7 +34723,7 @@ type AssignedSingleCategoryReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Referenced category."""
+  """The assigned category reference."""
   value: Category
 }
 
@@ -34613,7 +34739,7 @@ type AssignedSingleCollectionReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """Referenced collection."""
+  """The assigned collection reference."""
   value: Collection
 }
 
@@ -34629,7 +34755,7 @@ type AssignedMultiPageReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """List of referenced pages."""
+  """List of assigned page references."""
   value: [Page!]!
 }
 
@@ -34645,7 +34771,7 @@ type AssignedMultiProductReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """List of referenced products."""
+  """List of assigned product references."""
   value: [Product!]!
 }
 
@@ -34661,7 +34787,7 @@ type AssignedMultiProductVariantReferenceAttribute implements SelectedAttribute 
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """List of referenced product variants."""
+  """List of assigned product variant references."""
   value: [ProductVariant!]!
 }
 
@@ -34677,7 +34803,7 @@ type AssignedMultiCategoryReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """List of referenced categories."""
+  """List of assigned category references."""
   value: [Category!]!
 }
 
@@ -34693,7 +34819,7 @@ type AssignedMultiCollectionReferenceAttribute implements SelectedAttribute {
   """Values of an attribute."""
   values: [AttributeValue!]! @deprecated(reason: "Use type-specific fields instead.")
 
-  """List of referenced collections."""
+  """List of assigned collection references."""
   value: [Collection!]!
 }
 


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/18046

I want to merge this change because it adds the new `Assigned*Attribtue` type for the rest of types that were not yet covered. 

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/...